### PR TITLE
Add rpc credentials

### DIFF
--- a/LIGHTNING-00-install.md
+++ b/LIGHTNING-00-install.md
@@ -62,24 +62,24 @@ $ go install . ./cmd/...
 Running the following command will create `rpc.cert`  
 Bitcoin testnet blockchain is downloaded to `$HOME/.btcd` by default
 ```shell
-$ btcd --testnet --txindex 
+$ btcd --testnet --txindex --rpcuser=xu --rpcpass=xu
 ```
 
 Sync progress may be tracked as follows
 ```shell
-$ btcctl --testnet getinfo
+$ btcctl --testnet getinfo --rpcuser=xu --rpcpass=xu
 ```
 
 #### for Litecoin
 Running the following command will create `rpc.cert`  
 Litecoin testnet blockchain is downloaded to `$HOME/.ltcd` by default
 ```shell
-$ ltcd --testnet --txindex 
+$ ltcd --testnet --txindex --rpcuser=xu --rpcpass=xu
 ```
 
 Sync progress may be tracked as follows
 ```shell
-$ ltcctl --testnet  getinfo
+$ ltcctl --testnet  getinfo --rpcuser=xu --rpcpass=xu
 ```
 
 ## Running Lightning Daemon(s)

--- a/LIGHTNING-01-peers.md
+++ b/LIGHTNING-01-peers.md
@@ -12,7 +12,7 @@ Note that --debughtlc is currently mandatory for the success of a swap
 ```shell
 $ mkdir -p $HOME/exchange-a
 $ cd $HOME/exchange-a
-$ lnd --noencryptwallet --debughtlc --rpcport=10001 --peerport=10011 --restport=8001 --datadir=data --logdir=logs --debuglevel=info --nobootstrap --no-macaroons --bitcoin.active --bitcoin.testnet --litecoin.active --litecoin.testnet
+$ lnd --noencryptwallet --debughtlc --rpcport=10001 --peerport=10011 --restport=8001 --datadir=data --logdir=logs --debuglevel=info --nobootstrap --no-macaroons --bitcoin.active --bitcoin.testnet --litecoin.active --litecoin.testnet --bitcoin.rpcuser=xu --bitcoin.rpcpass=xu --litecoin.rpcuser=xu --litecoin.rpcpass=xu
 ```
 Give `lnd` the time it needs to sync with `btcd` and `ltcd`
 
@@ -86,7 +86,7 @@ Create a separate directory and launch `lnd` for Exchange B that uses both `Bitc
 ```shell
 $ mkdir -p $HOME/exchange-b
 $ cd $HOME/exchange-b
-$ lnd --noencryptwallet --debughtlc --rpcport=10002 --peerport=10012 --restport=8002 --datadir=data --logdir=logs --debuglevel=info --nobootstrap --no-macaroons --bitcoin.active --bitcoin.testnet --litecoin.active --litecoin.testnet
+$ lnd --noencryptwallet --debughtlc --rpcport=10002 --peerport=10012 --restport=8002 --datadir=data --logdir=logs --debuglevel=info --nobootstrap --no-macaroons --bitcoin.active --bitcoin.testnet --litecoin.active --litecoin.testnet --bitcoin.rpcuser=xu --bitcoin.rpcpass=xu --litecoin.rpcuser=xu --litecoin.rpcpass=xu
 ```
 Give `lnd` the time it needs to sync with `btcd` and `ltcd`
 


### PR DESCRIPTION
In going through these steps, it seems like these rpc options were required. RPC is disabled on btcd and ltcd without them: `NOTE: The RPC server is disabled by default if no rpcuser/rpcpass or rpclimituser/rpclimitpass is specified`.